### PR TITLE
Enhance GitHub Actions Triggers for Push and Pull Request Events on Key Branches

### DIFF
--- a/.github/workflows/code-quality-checks.yml
+++ b/.github/workflows/code-quality-checks.yml
@@ -2,9 +2,9 @@ name: Code Linters with Pylint & Bandit
 
 on:
   push:
-    branches: [ "ci/*", "feature/*", "fix/*", "refactor/*", "chore/*", "test/*" ]
+    branches: [ "development", "main", "quality", "ci/*", "feature/*", "fix/*", "refactor/*", "chore/*", "test/*" ]
   pull_request:
-    branches: [ "development", "master", "quality" ]
+    branches: [ "development", "main", "quality" ]
 
 jobs:
   build:


### PR DESCRIPTION
## **Why?**
This Pull Request adjusts the triggers for the GitHub Actions workflow. Previously, the actions were only triggered by *push* and *pull requests* on specific branches. The change broadens the scope to ensure that key branches, such as `development`, `main`, and `quality`, are also covered during *push* and *pull requests*.
