### PR TITLE
Add pytest-mock as a development dependency

### DIFF
--- a/config/poetry.lock
+++ b/config/poetry.lock
@@ -734,6 +734,23 @@ tomli = {version = ">=1", markers = "python_version < \"3.11\""}
 dev = ["argcomplete", "attrs (>=19.2)", "hypothesis (>=3.56)", "mock", "pygments (>=2.7.2)", "requests", "setuptools", "xmlschema"]
 
 [[package]]
+name = "pytest-mock"
+version = "3.14.0"
+description = "Thin-wrapper around the mock package for easier use with pytest"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "pytest-mock-3.14.0.tar.gz", hash = "sha256:2719255a1efeceadbc056d6bf3df3d1c5015530fb40cf347c0f9afac88410bd0"},
+    {file = "pytest_mock-3.14.0-py3-none-any.whl", hash = "sha256:0b72c38033392a5f4621342fe11e9219ac11ec9d375f8e2a0c164539e0d70f6f"},
+]
+
+[package.dependencies]
+pytest = ">=6.2.5"
+
+[package.extras]
+dev = ["pre-commit", "pytest-asyncio", "tox"]
+
+[[package]]
 name = "pytz"
 version = "2024.2"
 description = "World timezone definitions, modern and historical"
@@ -942,4 +959,4 @@ test = ["covdefaults (>=2.3)", "coverage (>=7.2.7)", "coverage-enable-subprocess
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "0bc0fb208a1292c08e6618d93dbb034effd7aaf508cb75fb8a7a4670a6f7aa60"
+content-hash = "2620a81db3d0b3ce824c563aaea2d4b5c0ff8c49d3ec0b12c414f86cc8b2f251"

--- a/config/pyproject.toml
+++ b/config/pyproject.toml
@@ -20,6 +20,7 @@ bandit = "^1.7.10"
 pylint = "^3.3.1"
 pytest = "^8.3.3"
 black = "^24.8.0"
+pytest-mock = "^3.14.0"
 
 [build-system]
 requires = ["poetry-core"]


### PR DESCRIPTION
Added pytest-mock to the development dependencies to enable mocking in unit tests.