### PR TITLE
ci(tests): add pytest workflow for running tests in tests directory

### DIFF
--- a/.github/workflows/pytest-workflow.yml
+++ b/.github/workflows/pytest-workflow.yml
@@ -1,0 +1,38 @@
+name: Run Pytest in Tests Directory
+
+on:
+  push:
+    branches: [ "quality", "test/*" ]
+  pull_request:
+    branches: [ "quality" ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11"]
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v3
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Copy pyproject.toml and poetry.lock
+      run: |
+        cp ./config/pyproject.toml ./pyproject.toml
+        cp ./config/poetry.lock ./poetry.lock
+    - name: Install Poetry
+      run: |
+        curl -sSL https://install.python-poetry.org | python3 -
+        export PATH="$HOME/.local/bin:$PATH"
+    - name: Install dependencies
+      run: |
+        poetry install --with dev
+    - name: Run Pytest
+      run: |
+        cd $GITHUB_WORKSPACE
+        poetry run pytest tests


### PR DESCRIPTION
- Added a GitHub Actions workflow to run pytest on the tests directory.
- Configured the workflow to trigger on push and pull requests to the 'quality' and 'test/*' branches.
- The workflow sets up Python 3.10 and 3.11 environments and installs dependencies using Poetry.